### PR TITLE
Replace SWFObject with <video> tag

### DIFF
--- a/art.html
+++ b/art.html
@@ -11,11 +11,10 @@
   <link type="text/css" rel="stylesheet" href="style2.css" />
 
   <script type="text/javascript" language="javascript" src="common.js"></script>
-  <script type="text/javascript" src="swfobject.js"></script>
 
 </head>
 
-<body onload="embed_player();">
+<body>
 
   <!-- Always on top: Position Fixed-->
   <header>
@@ -50,17 +49,7 @@
           </p>
 
          <div class="MovieBox" id="divMovieBox">
-              <!-- This will be replaced by SWFObject if flash exists -->
-
-              <div id="divFlashVersion" style="vertical-align: middle; height: 100px; margin-top: 150px; visibility: hidden;">
-                  It seems you do not have the required flash version to play this movie.
-                  <br />
-                  <br />
-                  Please download the <a href="Videos/YanirKleiman_2011_720x405.mov">quicktime version</a>
-                  or <a href="http://www.adobe.com/go/getflashplayer">get the latest flash player</a>.
-              </div>
-
-
+			 <video src="Videos/YanirKleiman_2011_HD720.mp4" preload controls width="100%"></video>
          </div>
 
             <p class="authors">

--- a/code.html
+++ b/code.html
@@ -11,11 +11,10 @@
   <link type="text/css" rel="stylesheet" href="style2.css" />
 
   <script type="text/javascript" language="javascript" src="common.js"></script>
-  <script type="text/javascript" src="swfobject.js"></script>
 
 </head>
 
-<body onload="embed_player();">
+<body>
 
   <!-- Always on top: Position Fixed-->
   <header>

--- a/common.js
+++ b/common.js
@@ -13,22 +13,6 @@
        var popup = document.getElementById("divPopup");
        popup.style.display = "none";
     }
-    
-    function embed_player()
-    {
-        var s1 = new SWFObject('player.swf','player','720','405','5');
-        s1.addParam('allowfullscreen','true');
-        s1.addParam('allowscriptaccess','always');
-        s1.addParam('flashvars','&file=https://dl.dropboxusercontent.com/u/640943/Site/Videos/YanirKleiman_DemoReel_2011.flv&controlbar=over&icons=false&image=https://dl.dropboxusercontent.com/u/640943/Site/Videos/LastFrame.jpg&plugins=gapro-1&gapro.accountid=UA-9716104-1');
-        s1.write('divMovieBox');
-
-        // if there is no flash this code will show the "no flash" message:
-        var noFlash = document.getElementById("divFlashVersion");
-        if (noFlash != null)
-        {
-           noFlash.style.visibility = "visible";
-        }
-    }
 
     function GetViewportHeight()
     {

--- a/style2.css
+++ b/style2.css
@@ -308,3 +308,11 @@ footer .Contact
     right: 0;
 }
 */
+
+video {
+	display: block;
+	text-align: center;
+	height: 300px;
+	width: 500px;
+	margin: auto;
+}


### PR DESCRIPTION
- Add an mp4 of the video, so we can use it as a single cross-browser source for video tags.
    - The required codecs are H264/MP3 in an MP4 file.
    - This is the command I used to make the file: `ffmpeg -i YanirKleiman_2011_HD720.mov -acodec mp3 -vcodec h264 YanirKleiman_2011_HD720.mp4`. Note the generated file was only 20MB, so maybe some different settings should be used for optimal viewing.
- Remove the SWFObject code from art.html
- Add a <video> tag to art.html.
